### PR TITLE
Increase activity log amount

### DIFF
--- a/src/app/api/activity/route.ts
+++ b/src/app/api/activity/route.ts
@@ -7,7 +7,7 @@ export async function GET() {
       orderBy: {
         createdAt: 'desc',
       },
-      take: 10,
+      take: 100,
       include: {
         team: true,
       },


### PR DESCRIPTION
## Summary
- fetch up to 100 activity logs for the dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b9a474f3483238761e11146c23217