### PR TITLE
Add admin metrics dashboard

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,9 +15,11 @@ import SubmissionsTab from '@/components/admin/SubmissionsTab';
 import ActivityLogTab from '@/components/admin/ActivityLogTab';
 import GameConfigurationTab from '@/components/admin/GameConfigurationTab';
 import SiteConfigurationTab from '@/components/admin/SiteConfigurationTab';
+import MetricsTab from '@/components/admin/MetricsTab';
 import { Tab } from '@/types';
 
 const TABS = [
+  { id: 'metrics' as Tab, label: 'Metrics' },
   { id: 'challenges' as Tab, label: 'Challenges' },
   { id: 'users' as Tab, label: 'Users' },
   { id: 'teams' as Tab, label: 'Teams' },
@@ -62,6 +64,7 @@ export default function AdminDashboard() {
         {/* Content Area - Conditionally render the active tab */}
         <div className="mt-6">
           {activeTab === 'challenges' && <ChallengesTab />}
+          {activeTab === 'metrics' && <MetricsTab />}
           {activeTab === 'users' && <UsersTab />}
           {activeTab === 'teams' && <TeamsTab />}
           {activeTab === 'submissions' && <SubmissionsTab />}

--- a/src/app/api/admin/metrics/route.ts
+++ b/src/app/api/admin/metrics/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function GET() {
+  try {
+    const session = await getServerSession(authOptions);
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
+    }
+
+    const [
+      totalTeams,
+      totalUsers,
+      totalChallenges,
+      totalSubmissions,
+      challenges,
+      teamScoreSum
+    ] = await Promise.all([
+      prisma.team.count(),
+      prisma.user.count(),
+      prisma.challenge.count(),
+      prisma.submission.count(),
+      prisma.challenge.findMany({
+        select: {
+          points: true,
+          flags: { select: { points: true } },
+          multipleFlags: true
+        }
+      }),
+      prisma.team.aggregate({ _sum: { score: true } })
+    ]);
+
+    let totalPossiblePoints = 0;
+    for (const ch of challenges) {
+      if (ch.multipleFlags && ch.flags.length > 0) {
+        totalPossiblePoints += ch.flags.reduce((sum, f) => sum + f.points, 0);
+      } else {
+        totalPossiblePoints += ch.points;
+      }
+    }
+
+    const totalPointsEarned = teamScoreSum._sum.score ?? 0;
+
+    return NextResponse.json({
+      totalTeams,
+      totalUsers,
+      totalChallenges,
+      totalSubmissions,
+      totalPossiblePoints,
+      totalPointsEarned
+    });
+  } catch (error) {
+    console.error('Error fetching metrics:', error);
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/admin/MetricsTab.tsx
+++ b/src/components/admin/MetricsTab.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react';
+import { ApiError, AdminMetrics } from '@/types';
+import { fetchAdminMetrics } from '@/utils/api';
+import LoadingSpinner from '@/components/common/LoadingSpinner';
+
+export default function MetricsTab() {
+  const [metrics, setMetrics] = useState<AdminMetrics | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadMetrics = async () => {
+      try {
+        const data = await fetchAdminMetrics();
+        setMetrics(data);
+      } catch (err) {
+        const error = err as ApiError;
+        setError(error.error);
+        console.error('Error fetching metrics:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadMetrics();
+  }, []);
+
+  if (isLoading) {
+    return <LoadingSpinner />;
+  }
+
+  if (error) {
+    return <div className="text-red-400">Error loading metrics: {error}</div>;
+  }
+
+  if (!metrics) return null;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Teams</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalTeams}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Users</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalUsers}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Challenges</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalChallenges}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Possible Points</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalPossiblePoints}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Submissions</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalSubmissions}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Points Earned</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalPointsEarned}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -256,6 +256,15 @@ export interface AdminActivityLog {
   team?: Team | null;
 }
 
+export interface AdminMetrics {
+  totalTeams: number;
+  totalUsers: number;
+  totalChallenges: number;
+  totalSubmissions: number;
+  totalPossiblePoints: number;
+  totalPointsEarned: number;
+}
+
 // SubmissionResponse
 export interface SubmissionResponse {
   message: string;
@@ -303,7 +312,8 @@ export type Tab =
   | 'announcements'
   | 'activity'
   | 'configuration'
-  | 'siteconfig';
+  | 'siteconfig'
+  | 'metrics';
 
 export interface RulesResponse {
   siteRules: string;

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -22,6 +22,7 @@ import {
   Team,
   AdminSubmission,
   AdminActivityLog,
+  AdminMetrics,
 } from '@/types';
 
 export async function fetchSiteConfig(): Promise<SiteConfig[]> {
@@ -459,6 +460,14 @@ export async function deleteAdminActivityLog(id: string): Promise<void> {
   }
 }
 
+export async function fetchAdminMetrics(): Promise<AdminMetrics> {
+  const response = await fetch('/api/admin/metrics');
+  if (!response.ok) {
+    throw new Error('Failed to fetch metrics');
+  }
+  return response.json();
+}
+
 export async function signUp(data: SignUpRequest): Promise<SignUpResponse> {
   const response = await fetch('/api/auth/signup', {
     method: 'POST',
@@ -492,4 +501,5 @@ export type {
   Team,
   AdminSubmission,
   AdminActivityLog,
+  AdminMetrics,
 };


### PR DESCRIPTION
## Summary
- add API endpoint to gather metrics for admin
- expose metrics via new API util
- create MetricsTab component
- add Metrics tab to admin page
- define AdminMetrics type and extend Tab union
- include total points earned metric

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684b728376248323840c269344c36295