### PR TITLE
Add total points metric to admin dashboard

### DIFF
--- a/src/components/admin/MetricsTab.tsx
+++ b/src/components/admin/MetricsTab.tsx
@@ -53,6 +53,10 @@ export default function MetricsTab() {
         <p className="text-3xl font-bold text-blue-400">{metrics.totalPossiblePoints}</p>
       </div>
       <div className="bg-gray-800 p-4 rounded border border-gray-700">
+        <h3 className="text-lg font-semibold mb-2">Points Scored</h3>
+        <p className="text-3xl font-bold text-blue-400">{metrics.totalPointsScored}</p>
+      </div>
+      <div className="bg-gray-800 p-4 rounded border border-gray-700">
         <h3 className="text-lg font-semibold mb-2">Submissions</h3>
         <p className="text-3xl font-bold text-blue-400">{metrics.totalSubmissions}</p>
       </div>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -263,6 +263,8 @@ export interface AdminMetrics {
   totalChallenges: number;
   totalSubmissions: number;
   totalPossiblePoints: number;
+  /** Total number of points all teams have accumulated */
+  totalPointsScored: number;
 }
 
 // SubmissionResponse


### PR DESCRIPTION
## Summary
- show how many points all teams have earned on the admin metrics page
- support new value in admin metrics API and types