### PR TITLE
Allow env-based game start and end times

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,5 @@ NEXTAUTH_URL="http://localhost:3000"
 DATABASE_URL=file:./dev.db
 INGEST_CHALLENGES_AT_STARTUP=true
 CHALLENGES_DIR="./challenges"
+GAME_START_TIME=""
+GAME_END_TIME=""

--- a/README.md
+++ b/README.md
@@ -132,9 +132,12 @@ NEXTAUTH_SECRET="your-secret-here"
 NEXTAUTH_URL="http://localhost:3000"
 INGEST_CHALLENGES_AT_STARTUP=true
 CHALLENGES_DIR="./challenges"
+GAME_START_TIME=""
+GAME_END_TIME=""
 ```
 
 Set `INGEST_CHALLENGES_AT_STARTUP` to `true` if you want challenges in `CHALLENGES_DIR` automatically imported when the server starts.
+`GAME_START_TIME` and `GAME_END_TIME` accept ISO 8601 date strings. When set, these values replace the existing start and end times in the database during server startup.
 
 ## 📝 License
 

--- a/src/app/api/game-config/route.ts
+++ b/src/app/api/game-config/route.ts
@@ -16,7 +16,7 @@ export async function GET() {
         isActive: false,
         startTime: null,
         endTime: null,
-        hasEndTime: true
+        hasEndTime: true,
       });
     }
 
@@ -25,7 +25,7 @@ export async function GET() {
       ...gameConfig,
       startTime: gameConfig.startTime.toISOString(),
       endTime: gameConfig.endTime?.toISOString() || null,
-      hasEndTime: gameConfig.endTime !== null
+      hasEndTime: gameConfig.endTime !== null,
     });
   } catch (error) {
     console.error('Error fetching game config:', error);

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,39 @@
+import { prisma } from '@/lib/prisma';
+
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     console.log('Running startup tasks...');
+
+    if (process.env.GAME_START_TIME || process.env.GAME_END_TIME) {
+      const envStart = process.env.GAME_START_TIME;
+      const envEnd = process.env.GAME_END_TIME;
+
+      const startDate = envStart ? new Date(envStart) : undefined;
+      const endDate = envEnd ? new Date(envEnd) : undefined;
+
+      if ((startDate && isNaN(startDate.getTime())) || (endDate && isNaN(endDate.getTime()))) {
+        console.error('Invalid GAME_START_TIME or GAME_END_TIME values');
+      } else {
+        const existingConfig = await prisma.gameConfig.findFirst();
+        if (existingConfig) {
+          await prisma.gameConfig.update({
+            where: { id: existingConfig.id },
+            data: {
+              ...(startDate ? { startTime: startDate } : {}),
+              ...(envEnd !== undefined ? { endTime: endDate ?? null } : {}),
+            },
+          });
+        } else if (startDate) {
+          await prisma.gameConfig.create({
+            data: {
+              startTime: startDate,
+              endTime: endDate ?? null,
+              isActive: true,
+            },
+          });
+        }
+      }
+    }
 
     if (process.env.INGEST_CHALLENGES_AT_STARTUP === 'true') {
       // Run challenge ingestion


### PR DESCRIPTION
## Summary
- let `GAME_START_TIME` and `GAME_END_TIME` replace DB values on startup
- document new environment variables in README
- revert route logic to just return DB values

## Testing
- `npm run lint`
- `npm run build` *(fails: Type errors in categories page)*

------
https://chatgpt.com/codex/tasks/task_e_68504aa2eb488323b9e78a143d4daf9c